### PR TITLE
Use the json module from stdlib (Python 2.6+) as fallback

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,10 @@ setup(name='sockjs-cyclone',
                  'sockjs.cyclone.transports'
                ],
       requires=[ 'twisted (>=12.0)',
-                 'cyclone (>=1.0)',
-                 'simplejson'
+                 'cyclone (>=1.0)'
                ],
       install_requires=[ 'twisted>=12.0',
-                         'cyclone>=1.0-rc8',
-                         'simplejson'
+                         'cyclone>=1.0-rc8'
                        ],
       classifiers=(
           'Development Status :: 5 - Production/Stable',

--- a/sockjs/cyclone/proto.py
+++ b/sockjs/cyclone/proto.py
@@ -1,4 +1,7 @@
-import simplejson
+try:
+    import simplejson
+except ImportError:
+    import json as simplejson
 
 json_encode = lambda data: simplejson.dumps(data, separators=(',', ':'))
 json_decode = lambda data: simplejson.loads(data)


### PR DESCRIPTION
Makes simplejson dependency optional on Python 2.6+
