### PR TITLE
Add chunk parameter of overloaded finish method

### DIFF
--- a/sockjs/cyclone/basehandler.py
+++ b/sockjs/cyclone/basehandler.py
@@ -32,11 +32,11 @@ class BaseHandler(RequestHandler):
             self.server.stats.connectionClosed()
             self.logged = False
 
-    def finish(self):
+    def finish(self, chunk=None):
         """ Cyclone C{finish} handler """
         self._log_disconnect()
 
-        super(BaseHandler, self).finish()
+        super(BaseHandler, self).finish(chunk)
 
     def on_connection_close(self, reason):
         self._log_disconnect()


### PR DESCRIPTION
Problem example:
RequestHandler calls write_error() which in turn calls self.finish() with a chunk parameter, leading to the uncaught exception "TypeError: finish() takes exactly 1 argument (2 given)"
