### PR TITLE
Expose User-Agent header in ConnectionInfo

### DIFF
--- a/sockjs/cyclone/conn.py
+++ b/sockjs/cyclone/conn.py
@@ -23,7 +23,8 @@ class ConnectionInfo(object):
     """
 
     _exposed_headers = set( ('origin', 'referer', 'x-client-ip',
-                             'x-forwarded-for', 'x-cluster-client-ip')
+                             'x-forwarded-for', 'x-cluster-client-ip',
+                             'user-agent')
                           )
 
     def __init__(self, ip, cookies, arguments, headers, path):


### PR DESCRIPTION
This PR allows the User-Agent header to be exposed by the ConnectionInfo class.

An alternative possibility would be to allow the library user to specify additional headers to expose via an optional dictionary in get_conn_info(), which could then be passed to the ConnectionInfo constructor.

If you prefer this alternative method, please let me know and I will update the PR.
